### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Geocoding Tool
+
+Electron desktop application for geocoding addresses in Bogotá, Colombia using the Google Geocoding API. See `README.md` for basic setup.
+
+## Cursor Cloud specific instructions
+
+### Running the app
+
+- **Install deps:** `npm install`
+- **Start app:** `npx electron . --no-sandbox` (must use `--no-sandbox` since the cloud VM runs as root)
+- **Start with DevTools:** `NODE_ENV=development npx electron . --no-sandbox`
+
+### Display server
+
+Electron requires a display. Start Xvfb before launching:
+
+```bash
+Xvfb :99 -screen 0 1280x1024x24 &
+export DISPLAY=:99
+```
+
+### Known non-blocking warnings
+
+When running headless, you'll see D-Bus and GPU errors in the terminal output — these are harmless and do not affect app functionality:
+- `Failed to connect to the bus: Could not parse server address`
+- `Exiting GPU process due to errors during initialization`
+
+### External dependencies
+
+- **Google Geocoding API key** is required at runtime for actual geocoding. The app UI prompts for it. Without it, the app still launches and the map renders, but address lookups will fail.
+- **Internet access** is needed for OpenStreetMap tiles and Google API calls.
+
+### Build/packaging
+
+- `npm run pack` — package into directory
+- `npm run dist` — build distributable installers (Windows/Linux/macOS)
+
+### Project structure
+
+- `main.js` — Electron main process (window creation, IPC handlers)
+- `preload.js` — Preload script (exposes `window.api`)
+- `index.html` — Main UI (Bootstrap + Leaflet map)
+- `js/geocoding.js` — Core geocoding logic
+- `geojson/` — Directory for GeoJSON boundary files (spatial intersection)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `AGENTS.md` file with development environment instructions specific to Cursor Cloud agents. This documents how to run the Electron app in a headless cloud VM environment.

## Key points documented

- How to run the app with `--no-sandbox` (required when running as root)
- Xvfb setup for headless display
- Known harmless D-Bus/GPU warnings
- External dependency notes (Google Geocoding API key, internet access)
- Project structure overview

## Evidence of working environment

The app launches successfully and renders the full UI including the Leaflet/OpenStreetMap map:

[Geocoding Tool running](https://cursor.com/agents/bc-3aa2094c-3449-4d91-b0f4-a3d0c45222a9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgeocoding_app_running.png)

[geocoding_tool_demo.mp4](https://cursor.com/agents/bc-3aa2094c-3449-4d91-b0f4-a3d0c45222a9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgeocoding_tool_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3aa2094c-3449-4d91-b0f4-a3d0c45222a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3aa2094c-3449-4d91-b0f4-a3d0c45222a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

